### PR TITLE
Add support for both legacy and UEFI boot

### DIFF
--- a/dhcp/dhcpd.conf
+++ b/dhcp/dhcpd.conf
@@ -23,13 +23,16 @@ shared-network management {
         # option bootfile-name "snponly64.efi.vmw-hardwired";
         # filename "snponly64.efi.vmw-hardwired";
         # filename "pxelinux.0";
-        if exists user-class and option user-class = "iPXE" {
+        if exists user-class and option user-class = "iPXE" and option client-architecture = 00:00 {
             filename "http://10.115.37.201/script.ipxe";
+        } elsif exists user-class and option user-class = "iPXE" and option client-architecture = 00:07 {
+            filename "http://10.115.37.201/script.uefi.ipxe";
         } elsif option client-architecture = 00:00 {
             filename "undionly.kpxe";
             # filename "pxelinux.0"
         } else {
-            filename "ipxe.efi";
+            filename "mboot.efi";
+            # filename "snponly.efi";
         }
         next-server 10.115.37.201;
         default-lease-time 86400;
@@ -57,3 +60,8 @@ shared-network management {
         range 10.115.37.201 10.115.37.250;
     }
 }
+
+
+
+
+


### PR DESCRIPTION
- If legacy, boot ipxe first and then script.ipxe which chain boot pxelinux.0. This is so we can use HTTP for PXE.
- If UEFI, then just boot mboot.efi directly. Assume UEFI already support HTTP